### PR TITLE
Remove ~/Mods before symlinking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,8 @@ RUN steamcmd \
 
 # Setup mods folder
 RUN mv $INSTALL_LOC/Mods/* $MODS_LOC && \
-    ln -fs $MODS_LOC $INSTALL_LOC/Mods && \
+    rmdir $INSTALL_LOC/Mods && \
+    ln -s $MODS_LOC $INSTALL_LOC/Mods && \
     ln -s $MODS_LOC/config_player.xml $INSTALL_LOC/config_player.xml && \
     # Setup config folder
     mv \


### PR DESCRIPTION
`ln-fs` was creating `/mods -> ~/Mods/mods` instead of symlinking `/mods -> ~/Mods`.
This appears to be because the `-f` flag only works on files, not directories.

The solution is to remove the directory before symlinking.